### PR TITLE
Added socket type check

### DIFF
--- a/netstat/netstat_linux.go
+++ b/netstat/netstat_linux.go
@@ -197,7 +197,7 @@ func (p *procFd) iterFdDir() {
 	for _, file := range fi {
 		fd := path.Join(fddir, file.Name())
 		lname, err := os.Readlink(fd)
-		if err != nil {
+		if err != nil || !strings.Contains(lname, "socket") {{
 			continue
 		}
 

--- a/netstat/netstat_linux.go
+++ b/netstat/netstat_linux.go
@@ -197,8 +197,8 @@ func (p *procFd) iterFdDir() {
 	for _, file := range fi {
 		fd := path.Join(fddir, file.Name())
 		lname, err := os.Readlink(fd)
-		if err != nil || !strings.Contains(lname, "socket") {{
-			continue
+		if err != nil || !strings.HasPrefix(lname, sockPrefix) {
+                   continue
 		}
 
 		for i := range p.sktab {


### PR DESCRIPTION
In some cases, where server is running with thousands of connections, looping through all the file descriptors takes times. I have tested on a server with 20k connections and it took around 1m30s to get all socket information. After adding !strings.Contains(lname, "socket") to the loop the cost reduced significantly to  around 25 seconds.