### PR TITLE
simply return error

### DIFF
--- a/netstat/netstat_linux.go
+++ b/netstat/netstat_linux.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"path"
@@ -103,7 +102,7 @@ func parseAddr(s string) (*SockAddr, error) {
 	case ipv6StrLen:
 		ip, err = parseIPv6(fields[0])
 	default:
-		log.Fatal("Bad formatted string")
+		err = fmt.Errorf("netstat: bad formatted string: %v", fields[0])
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Thank you for creating this useful library.

Currently, go-netstat may terminate the whole program if it fails to parse socktabs.

Because go-netstat is a library, I think it is better to return an error instead of terminating the whole program.