### PR TITLE
avoid costly process info extraction if unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+###  This fork avoids costly process info extraction if all necessary calculation was done in AcceptFn function and it always returns false.
 ### Usage:
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/cakturk/go-netstat
+module github.com/sokurenko/go-netstat
 
 go 1.13

--- a/netstat/netstat_linux.go
+++ b/netstat/netstat_linux.go
@@ -257,7 +257,11 @@ func doNetstat(path string, fn AcceptFn) ([]SockTabEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	extractProcInfo(tabs)
+
+	if len(tabs) != 0 {
+		extractProcInfo(tabs)
+	}
+
 	return tabs, nil
 }
 


### PR DESCRIPTION
We need to calculate socket count in listen state and it takes lots of resources to calculate:
time ./sbin/zabbix_agent2 -t net.tcp.socket.count[,,,,listen]
net.tcp.socket.count[,,,,listen]              [s|38983]

user	0m32.999s
sys	0m0.470s

However if we modify AcceptFn always to return false and only increase counter when required then everything becomes fast:
time ./sbin/zabbix_agent2 -t net.tcp.socket.count[,,,,listen]
net.tcp.socket.count[,,,,listen]              [s|38983]

user	0m0.143s
sys	0m0.296s

However it is possible to improve even further with the fix in pull request:
time ./sbin/zabbix_agent2 -t net.tcp.socket.count[,,,,listen]
net.tcp.socket.count[,,,,listen]              [s|38983]

user	0m0.060s
sys	0m0.069s

Please accept pull request, also it would be nice to document that AcceptFn can be used to calculate data without returning it as it is pretty CPU intensive, thank you!

This is required for https://support.zabbix.com/browse/ZBX-21300